### PR TITLE
Added the Due dates in Apple Reminders

### DIFF
--- a/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
+++ b/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
@@ -277,6 +277,7 @@ class ActionItemTileWidget extends StatelessWidget {
   final success = await service.addReminder(
       title: actionItem.description,
       notes: 'From Omi',
+      dueDate: actionItem.dueAt,
       listName: 'Reminders',
     );
     


### PR DESCRIPTION
### What this PR does
This PR fixes the Apple Reminders integration to include due dates when exporting action items. Previously, reminders were created without due dates, causing them to appear only with time information. Now, reminders are properly scheduled with the full date and time from the action item.

### Screenshots
| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-12 at 19 48 54" src="https://github.com/user-attachments/assets/c3927154-f4ba-4b61-8f32-1a0bae299cde" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-12 at 20 05 54" src="https://github.com/user-attachments/assets/27b282c0-4b92-4df6-9d8e-d80ae081e316" />| 

### Video Demo and Code Walkthrough
https://youtu.be/vIi7TE5XlTo

### Changes
- Added dueDate parameter to service.addReminder() call (line 227)
- Due date is now passed from actionItem.dueAt to Apple Reminders

Fixes #7 